### PR TITLE
change docker base image to mongo:5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,13 +1,6 @@
-FROM ubuntu:20.04
+FROM mongo:5
 
-RUN apt-get update
-RUN apt-get install -y gnupg wget
-RUN wget -qO - https://www.mongodb.org/static/pgp/server-5.0.asc | apt-key add -
-RUN echo "deb [ arch=amd64,arm64 ] https://repo.mongodb.org/apt/ubuntu focal/mongodb-org/5.0 multiverse" | tee /etc/apt/sources.list.d/mongodb-org-5.0.list
-RUN apt-get update
-RUN apt-get install -y mongodb-mongosh
-
-RUN mkdir /entrypoint
+RUN mkdir -p /entrypoint
 COPY ./entrypoint.sh /entrypoint/entrypoint.sh
 RUN chmod +x /entrypoint/entrypoint.sh
 


### PR DESCRIPTION
Since ubuntu base image was too big and I learned that mongosh is already contained in the mongo docker image, I switched.